### PR TITLE
Fixed login packet writer

### DIFF
--- a/Components/MineSharp.Protocol/Packets/Clientbound/Play/LoginPacket.cs
+++ b/Components/MineSharp.Protocol/Packets/Clientbound/Play/LoginPacket.cs
@@ -117,11 +117,11 @@ public class LoginPacket : IPacket
         buffer.WriteBool(this.IsFlat);
         
         buffer.WriteBool(this.HasDeathLocation);
-        if (!this.HasDeathLocation)
-            return;
-
-        buffer.WriteString(this.DeathDimensionName!);
-        buffer.WriteULong(this.DeathLocation!.ToULong());
+        if (this.HasDeathLocation)
+        {
+            buffer.WriteString(this.DeathDimensionName!);
+            buffer.WriteULong(this.DeathLocation!.ToULong());
+        }
 
         if (version.Version.Protocol >= ProtocolVersion.V_1_20)
         {


### PR DESCRIPTION
This pull request fixes the login packet writer for protocol versions 1.20.2 and above. Before, the Write method skipped the PortalCooldown value.