### PR TITLE
Wait for game not return fix

### DIFF
--- a/Components/MineSharp.Protocol/Exceptions/DisconnectedException.cs
+++ b/Components/MineSharp.Protocol/Exceptions/DisconnectedException.cs
@@ -1,0 +1,10 @@
+﻿namespace MineSharp.Protocol.Exceptions;
+
+/// <inheritdoc />
+public class DisconnectedException(string message, string reason) : MineSharpHostException(message)
+{
+    /// <summary>
+    /// The reason of the disconnect
+    /// </summary>
+    public string Reason { get; private set; } = reason;
+}

--- a/Components/MineSharp.Protocol/MinecraftClient.cs
+++ b/Components/MineSharp.Protocol/MinecraftClient.cs
@@ -202,6 +202,10 @@ public sealed class MinecraftClient : IDisposable
     public async Task Disconnect(string reason = "disconnect.quitting")
     {
         Logger.Info($"Disconnecting: {reason}");
+        
+        if (!_gameJoinedTsc.Task.IsCompleted)
+            _gameJoinedTsc.SetException(new DisconnectedException($"Client has been disconnected", reason));
+        
         if (this._client is null)
             throw new InvalidOperationException("MinecraftClient is not connected.");
 


### PR DESCRIPTION
This pr fixes `await MinecraftClient.WaitForGame()` is stuck due to _gameJoinedTsc was never completed if the bot did not make it to Game State